### PR TITLE
Remove mutability on middlewares and replace the deprecated apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,9 @@ private func decrement(counter: inout Counter, payload: Int) {
 
 ## Action
 
-Action is also defined by the store's method. There is no need to create a separate custom data type for action anymore.
+Action is also defined by the store's method. There is no need to create a separate custom data type for action anymore. Since Action is defined as a store method, there are very few cases where the store's dispatch method is actually used. 
+
+Action can be defined by dividing it into Sync Action or Async Action. Since the state change occurs in the commit, there is no need to define additional middleware for asynchronous processing. You can complete asynchronous processing in the async action and then commit the changes.
 
 ```swift
 // actions
@@ -103,8 +105,6 @@ func asyncDecrementAction(payload: Int) async {
 }
 ```
 
-Since Action is defined as a store method, there are very few cases where the store's dispatch method is actually used.
-
 
 ## Computed
 
@@ -116,7 +116,7 @@ class CounterStore: Store<Counter> {
         super.init(state: Counter())
     }
     
-    // refs or computed
+    // computed
     @Published
     var count = 0
     
@@ -144,7 +144,7 @@ class CounterStore: Store<Counter> {
         super.init(state: Counter())
     }
     
-    // refs or computed
+    // computed
     @Published
     var count = 0
     
@@ -183,9 +183,11 @@ class CounterStore: Store<Counter> {
 ```
 
 
-## Middleware
+## Middlewares
 
 You can optionally add middlewares. Middleware is a collection of functions called before or after all Mutations.
+
+You can optionally add Middleware. Middleware is a collection of sync functions called before and after all mutations are commited. For example, you can define middleware that print logs to debug state changes.
 
 ```swift
 class WorksBeforeCommitStore: Store<ReduxState> {
@@ -193,10 +195,10 @@ class WorksBeforeCommitStore: Store<ReduxState> {
         super.init(state: ReduxState())
     }
     
-    override func worksBeforeCommit() -> [(inout ReduxState) -> Void] {
+    override func worksBeforeCommit() -> [(ReduxState) -> Void] {
         return [
-            { (mutableState) in
-                mutableState.count = -10
+            { (state) in
+                print(state.count)
             }
         ]
     }
@@ -207,10 +209,10 @@ class WorksAfterCommitStore: Store<ReduxState> {
         super.init(state: ReduxState())
     }
     
-    override func worksAfterCommit() -> [(inout ReduxState) -> Void] {
+    override func worksAfterCommit() -> [(ReduxState) -> Void] {
         return [
-            { (mutableState) in
-                mutableState.count *= 2
+            { (state) in
+                print(state.count)
             }
         ]
     }

--- a/README_ko.md
+++ b/README_ko.md
@@ -80,7 +80,7 @@ private func decrement(counter: inout Counter, payload: Int) {
 
 ## Action 정의
 
-Action 도 Store의 메서드로 정의합니다. 더 이상 Action을 위해 따로 struct와 같은 타입을 만들 필요가 없습니다. 
+Action 도 Store의 메서드로 정의합니다. 더 이상 Action을 위해 따로 struct와 같은 타입을 만들 필요가 없습니다. Action을 Store의 메서드로 정의하기 때문에 실제로 Store의 dispatch 메서드를 사용하는 경우는 매우 적습니다. Action은 Sync Action 또는 Async Action으로 나누어 정의할 수 있습니다. 상태 변경은 commit mutation 에서 발생하기 때문에 비동기 처리를 위해서 부가적인 middleware를 정의할 필요가 없습니다. 비동기 액션에서 비동기 처리를 완료한 다음 변경사항을 커밋하면 됩니다.
 
 ```swift
 // actions
@@ -103,8 +103,6 @@ func asyncDecrementAction(payload: Int) async {
 }
 ```
 
-Action을 Store의 메서드로 정의하기 때문에 실제로 Store의 dispatch 메서드를 사용하는 경우는 매우 적습니다.
-
 
 ## Computed
 
@@ -116,7 +114,7 @@ class CounterStore: Store<Counter> {
         super.init(state: Counter())
     }
     
-    // refs or computed
+    // computed
     @Published
     var count = 0
     
@@ -144,7 +142,7 @@ class CounterStore: Store<Counter> {
         super.init(state: Counter())
     }
     
-    // refs or computed
+    // computed
     @Published
     var count = 0
     
@@ -185,7 +183,7 @@ class CounterStore: Store<Counter> {
 
 ## Middleware 정의
 
-선택적으로 Middleware를 추가할 수 있습니다. 미들웨어는 모든 Mutation 전 또는 후에 호출되는 함수 모음입니다.
+선택적으로 Middleware를 추가할 수 있습니다. 미들웨어는 모든 Mutation이 commit되기 전과 후에 호출되는 동기 함수 모음입니다. 예를 들어 상태 변경을 디버깅하기 위해 로그를 출력하는 미들웨어를 정의할 수 있습니다.
 
 ```swift
 class WorksBeforeCommitStore: Store<ReduxState> {
@@ -193,10 +191,10 @@ class WorksBeforeCommitStore: Store<ReduxState> {
         super.init(state: ReduxState())
     }
     
-    override func worksBeforeCommit() -> [(inout ReduxState) -> Void] {
+    override func worksBeforeCommit() -> [(ReduxState) -> Void] {
         return [
-            { (mutableState) in
-                mutableState.count = -10
+            { (state) in
+                print(state.count)
             }
         ]
     }
@@ -207,10 +205,10 @@ class WorksAfterCommitStore: Store<ReduxState> {
         super.init(state: ReduxState())
     }
     
-    override func worksAfterCommit() -> [(inout ReduxState) -> Void] {
+    override func worksAfterCommit() -> [(ReduxState) -> Void] {
         return [
-            { (mutableState) in
-                mutableState.count *= 2
+            { (state) in
+                print(state.count)
             }
         ]
     }

--- a/Redux.xcodeproj/xcshareddata/xcschemes/Redux-Package.xcscheme
+++ b/Redux.xcodeproj/xcshareddata/xcschemes/Redux-Package.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Tests/MockStore/CounterStore.swift
+++ b/Tests/MockStore/CounterStore.swift
@@ -47,12 +47,12 @@ class CounterStore: Store<Counter> {
     }
     
     func asyncIncrementAction(payload: Int) async {
-        await Task.sleep(1 * 1_000_000_000)
+        try? await Task.sleep(nanoseconds: 1 * 1_000_000_000)
         self.commit(mutation: increment, payload: payload)
     }
     
     func asyncDecrementAction(payload: Int) async {
-        await Task.sleep(1 * 1_000_000_000)
+        try? await Task.sleep(nanoseconds: 1 * 1_000_000_000)
         self.commit(mutation: decrement, payload: payload)
     }
 }

--- a/Tests/ReduxTests/ContextSwitching.swift
+++ b/Tests/ReduxTests/ContextSwitching.swift
@@ -10,5 +10,5 @@ import Foundation
 
 /// for testing the computed property
 func contextSwitching() async {
-    await Task.sleep(UInt64(0.1 * 1_000_000_000))
+    try? await Task.sleep(nanoseconds: 1 * 1_000_000_000)
 }


### PR DESCRIPTION
## summary

- Remove mutability on middlewares and replace the deprecated apis

## changes

- remove mutability on worksBefeoreCommit and worksAfterCommit
- replace Task.sleep(_:) to Task.sleep(nanoseconds:)
- update README.md