### PR TITLE
Add commit(mutation:) method

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Redux only support Swift Package Manager.
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/ReactComponentKit/Redux.git", from: "1.2.0"),
+    .package(url: "https://github.com/ReactComponentKit/Redux.git", from: "1.2.1"),
 ]
 ```
 
@@ -102,6 +102,37 @@ func asyncIncrementAction(payload: Int) async {
 func asyncDecrementAction(payload: Int) async {
     await Task.sleep(1 * 1_000_000_000)
     self.commit(mutation: decrement, payload: payload)
+}
+```
+
+Also, You can use simplified commit method to define action or mutate state.
+
+```swift
+func asyncIncrementAction(payload: Int) async {
+    await Task.sleep(1 * 1_000_000_000)
+    self.commit { mutableState in 
+        mutableState.count += 1
+    }
+}
+```
+
+Store's `commit` method is public so you can use it on the UI layer.
+
+```swift
+Button(action: { store.counter.commit { $0.count += 1 }) {
+    Text(" + ")
+        .font(.title)
+        .bold()
+}
+```
+
+or use store's action method.
+
+```swift
+Button(action: { store.counter.incrementAction(payload: 1) }) {
+    Text(" + ")
+        .font(.title)
+        .bold()
 }
 ```
 

--- a/README_ko.md
+++ b/README_ko.md
@@ -103,6 +103,37 @@ func asyncDecrementAction(payload: Int) async {
 }
 ```
 
+또한 `commit(mutation:payload:)` 메서드 대신에 `commit(mutation:)` 메서드를 사용하여 액션을 정의하거나 상태를 수정할 수 있습니다.
+
+```swift
+func asyncIncrementAction(payload: Int) async {
+    await Task.sleep(1 * 1_000_000_000)
+    self.commit { mutableState in 
+        mutableState.count += 1
+    }
+}
+```
+
+스토어의 `commit` 메서드는 public 입니다. 따라서 아래와 같이 UI 레이어에서 바로 상태를 수정하는 액션을 실행할 수 있습니다.
+
+```swift
+Button(action: { store.counter.commit { $0.count += 1 }) {
+    Text(" + ")
+        .font(.title)
+        .bold()
+}
+```
+
+아니면 스토어의 액션 메서드를 실행해도 됩니다.
+
+```swift
+Button(action: { store.counter.incrementAction(payload: 1) }) {
+    Text(" + ")
+        .font(.title)
+        .bold()
+}
+```
+
 
 ## Computed
 

--- a/Sources/Redux/Store.swift
+++ b/Sources/Redux/Store.swift
@@ -80,6 +80,16 @@ open class Store<S: State>: ObservableObject {
         }
     }
     
+    public func commit(mutation: (inout S) -> Void) {
+        doWorksBeforeCommit()
+        let old = state
+        mutation(&state)
+        doWorksAfterCommit()
+        Task {
+            await computeOnMainThread(new: state, old: old)
+        }
+    }
+    
     public func dispatch<P>(action: (Store<S>, P) async -> Void, payload: P) async {
         await action(self, payload)
     }

--- a/Tests/ReduxTests/CounterStoreTests.swift
+++ b/Tests/ReduxTests/CounterStoreTests.swift
@@ -68,4 +68,22 @@ final class CounterStoreTests: XCTestCase {
         await store.asyncDecrementAction(payload: 10)
         XCTAssertEqual(-11, store.state.count)
     }
+    
+    func testCommitWithClosure() async {
+        XCTAssertEqual(0, store.count)
+        
+        store.commit { state in
+            state.count += 100
+        }
+        XCTAssertEqual(100, store.state.count)
+        await contextSwitching()
+        XCTAssertEqual(100, store.count)
+        
+        store.commit { state in
+            state.count -= 10
+        }
+        XCTAssertEqual(90, store.state.count)
+        await contextSwitching()
+        XCTAssertEqual(90, store.count)
+    }
 }

--- a/Tests/ReduxTests/ReduxTests.swift
+++ b/Tests/ReduxTests/ReduxTests.swift
@@ -66,11 +66,18 @@ final class ReduxTests: XCTestCase {
         store = nil
     }
     
-    func testCommit() {
+    func testCommitWithPayload() {
         store.commit(mutation: { mutableState, number in
             mutableState.count += number
         }, payload: 10)
         XCTAssertEqual(10, store.state.count)
+    }
+    
+    func testCommitWithClosure() {
+        store.commit { mutableState in
+            mutableState.count += 99
+        }
+        XCTAssertEqual(99, store.state.count)
     }
     
     func testDispatchSync() {


### PR DESCRIPTION
## Summary

Add commit(mutation:) which has no payload parameter. We can reduce the codes to define store's action like below:

```swift
Button(action: { store.counter.incrementAction(payload: 1) }) {
    Text(" + ")
        .font(.title)
        .bold()
}
```

to be

```swift
Button(action: { store.counter.commit { $0.count += 1 }) {
    Text(" + ")
        .font(.title)
        .bold()
}
```


## Changed

- add commit(mutation:) method.
- update README.md
- update UnitTest